### PR TITLE
Use multi-stage Docker build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
 FROM node:7
+
+COPY package.json /tmp/
+WORKDIR /tmp/
+RUN npm install
+
+FROM node:7
 ENV NPM_CONFIG_LOGLEVEL error
 
 # /usr/app is the root of our code in the container
@@ -6,6 +12,7 @@ WORKDIR /usr/app
 
 # Bundle our source code in the container
 COPY . /usr/app/
+COPY --from=0 /tmp/node_modules /usr/app/node_modules
 
 # Install dependencies
 RUN npm install


### PR DESCRIPTION
In order to speed up the agent build process significantly it makes sense to cache the npm dependency resolution by using a Docker multi-stage build. The package.json busts the build cache.

N.B.: multi-stage builds require Docker v17.05+.